### PR TITLE
mirrors: update region to reflect availability

### DIFF
--- a/_data/mirrors.yml
+++ b/_data/mirrors.yml
@@ -1,44 +1,44 @@
 repo:
     url: https://repo.aosc.io/
     name: AOSC Main Repo
-    region: US
+    region: US (IPv4/IPv6)
 mirrors:
     - name: Tencent OSS Mirror
       url: https://mirrors.cloud.tencent.com/anthon/
-      region: China
+      region: China (IPv4 only)
     - name: LZUOSS 兰州大学
       url: https://mirror.lzu.edu.cn/anthon/
-      region: China
+      region: China (IPv4/IPv6)
     - name: Nanjing University
       url: https://mirrors.nju.edu.cn/anthon/
-      region: China
+      region: China (IPv4/IPv6)
     - name: Tsinghua University (TUNA)
       url: https://mirrors.tuna.tsinghua.edu.cn/anthon/
-      region: China
+      region: China (IPv4/IPv6)
     - name: LUG@USTC
       url: https://mirrors.ustc.edu.cn/anthon/
-      region: China
+      region: China (IPv4/IPv6)
     - name: Geekpie Association
       url: https://mirrors.geekpie.club/anthon/
-      region: China
-    - name: UESTC LUG (IPv6 only)
+      region: China (IPv4 only)
+    - name: UESTC LUG
       url: https://mirrors.uestc.cn/anthon/
-      region: China
+      region: China (IPv6 only)
     - name: xTom
       url: https://mirror.xtom.com.hk/anthon/
-      region: Hong Kong
+      region: Hong Kong (IPv4/IPv6)
     - name: University of Tsukuba
       url: http://ftp.tsukuba.wide.ad.jp/Linux/anthon/
-      region: Japan
+      region: Japan (IPv4/IPv6)
     - name: NLUUG
       url: https://ftp.nluug.nl/os/Linux/distr/anthon/
-      region: Europe
+      region: Europe (IPv4/IPv6)
     - name: KoDDoS
       url: https://mirror.koddos.net/anthon/
-      region: Europe
+      region: Europe (IPv4/IPv6)
     - name: KoDDoS HK
       url: https://mirror-hk.koddos.net/anthon/
-      region: Hong Kong
+      region: Hong Kong (IPv4/IPv6)
     - name: Fastly CDN
       url: https://aosc-repo.freetls.fastly.net/
-      region: Worldwide
+      region: Outside of China (IPv4/IPv6)


### PR DESCRIPTION
Fastly is not available in China, and not all mirrors has IPv6 address. Also, move "IPv6 only" info into region.