### PR TITLE
i18n/zh-cn: use ustc font mirror

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -44,6 +44,9 @@
     {{- else if eq .Site.Language.Lang "lzh" -}}
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Noto+Serif+TC:400,600&display=swap" />
     <style>body{font-family:'Noto Serif TC',serif;}</style>
+    {{- else if eq .Site.Language.Lang "zh-cn" -}}
+    <link href="https://fonts.lug.ustc.edu.cn/css2?family=Noto+Serif+SC:wght@400;600&display=swap" rel="stylesheet"> 
+    <style>body{font-family:'Noto Serif SC',serif;}</style>
     {{- else -}}
     <link href="https://fonts.googleapis.com/css2?family=Noto+Serif+SC:wght@400;600&display=swap" rel="stylesheet"> 
     <style>body{font-family:'Noto Serif SC',serif;}</style>

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -45,7 +45,7 @@
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Noto+Serif+TC:400,600&display=swap" />
     <style>body{font-family:'Noto Serif TC',serif;}</style>
     {{- else if eq .Site.Language.Lang "zh-cn" -}}
-    <link href="https:///fonts.proxy.ustclug.org/css2?family=Noto+Serif+SC:wght@400;600&display=swap" rel="stylesheet"> 
+    <link href="https://fonts.proxy.ustclug.org/css2?family=Noto+Serif+SC:wght@400;600&display=swap" rel="stylesheet"> 
     <style>body{font-family:'Noto Serif SC',serif;}</style>
     {{- else -}}
     <link href="https://fonts.googleapis.com/css2?family=Noto+Serif+SC:wght@400;600&display=swap" rel="stylesheet"> 

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -45,7 +45,7 @@
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Noto+Serif+TC:400,600&display=swap" />
     <style>body{font-family:'Noto Serif TC',serif;}</style>
     {{- else if eq .Site.Language.Lang "zh-cn" -}}
-    <link href="https://fonts.lug.ustc.edu.cn/css2?family=Noto+Serif+SC:wght@400;600&display=swap" rel="stylesheet"> 
+    <link href="https:///fonts.proxy.ustclug.org/css2?family=Noto+Serif+SC:wght@400;600&display=swap" rel="stylesheet"> 
     <style>body{font-family:'Noto Serif SC',serif;}</style>
     {{- else -}}
     <link href="https://fonts.googleapis.com/css2?family=Noto+Serif+SC:wght@400;600&display=swap" rel="stylesheet"> 


### PR DESCRIPTION
When the language is zh-cn, use ustc's Google Fonts mirror to solve the problem of slow loading in mainland China