### PR TITLE
Propose of using paste.aosc.io as default pastebin

### DIFF
--- a/content/news/posts/2020-08-06-a-facelift-for-aosc-pastebin.md
+++ b/content/news/posts/2020-08-06-a-facelift-for-aosc-pastebin.md
@@ -1,0 +1,51 @@
+---
+categories:
+  - news
+title: A Facelift for AOSC Pastebin
+date: '2020-08-06'
+important: false
+---
+
+The AOSC Pastebin has recently gone through a facelift.
+
+The new pastebin is a proxy to our old pastebin service, with a completely redesigned
+UI that more closely resembles our main website, and uses no JavaScript in
+order to improve compatibility, accessibility, and speed.
+
+The new pastebin is now online, accessible at https://paste.aosc.io .
+
+Any Compatibility Issues?
+-------------------------
+As far as we know, currently most of the basic functions are fully supported by the new
+Pastebin system. This includes basic pasting, setting title, deactivating, and set
+expiration time.
+
+A few functions are however left off. This includes:
+- Multiple attachments: one attachment shall be sufficient. By the way, who uses a Pastebin to store attachments, especially in binary format?
+- Syntax highlighting: This unfortunately was accomplished in JavaScript, so for now forget about it.
+- Password: It is slightly more complex. It might be included in a future update though.
+
+This info would be updated on the new pastebin's [about page](https://paste.aosc.io/about.html).
+
+How About Our Old Pastebin? 
+---------------------------
+
+For those who still miss the good'ol Pastebin that is now serving as the backend of our
+new Pastebin, either because they need a function that is not offered in the new Pastebin
+as indicated above, or they can't give up the convenience offered by the JavaScript
+such as the eyecandies and the syntax highlighting, or because they just have too much
+computational power to waste (Hey you are blessed!), please beware that
+our old Pastebin is still running on https://pastebin.aosc.io . A link is also offered
+at the bottom of each paste on the new Pastebin, to allow users to view them on the old
+Pastebin.
+
+Hey I've Got a Question!
+----------
+
+If you have any further questions or feature requests, please contact the owner _S. aureus_
+
+Enjoy Pasting the AOSC way!
+
+----
+
+— _S. aureus_

--- a/content/news/posts/2020-08-06-a-facelift-for-aosc-pastebin.md
+++ b/content/news/posts/2020-08-06-a-facelift-for-aosc-pastebin.md
@@ -16,33 +16,33 @@ The new pastebin is now online, accessible at https://paste.aosc.io .
 
 Any Compatibility Issues?
 -------------------------
-As far as we know, currently most of the basic functions are fully supported by the new
-Pastebin system. This includes basic pasting, setting title, deactivating, and set
+Currently most basic functions are fully supported by the new
+Pastebin website. This includes basic pasting, setting title, deactivating, and setting
 expiration time.
 
-A few functions are however left off. This includes:
-- Multiple attachments: one attachment shall be sufficient. By the way, who uses a Pastebin to store attachments, especially in binary format?
-- Syntax highlighting: This unfortunately was accomplished in JavaScript, so for now forget about it.
-- Password: It is slightly more complex. It might be included in a future update though.
+However, a few non-essential functions are left off. This includes:
+- Multiple attachments: one attachment should be sufficient. If not, you can always tar/zip them.
+- Syntax highlighting: This was accomplished in JavaScript, so it is not implemented now.
+- Password: It is slightly more complex. We need more time to implement it.
 
-This info would be updated on the new pastebin's [about page](https://paste.aosc.io/about.html).
+Future updates regarding which functions are getting implemented or left off would be updated on the new pastebin's [about page](https://paste.aosc.io/about.html).
 
 How About Our Old Pastebin? 
 ---------------------------
 
-For those who still miss the good'ol Pastebin that is now serving as the backend of our
-new Pastebin, either because they need a function that is not offered in the new Pastebin
-as indicated above, or they can't give up the convenience offered by the JavaScript
-such as the eyecandies and the syntax highlighting, or because they just have too much
-computational power to waste (Hey you are blessed!), please beware that
+For those of you who still miss the good'ol Pastebin (which is now serving as the backend of our
+new Pastebin), either because you need a function that is not offered in the new Pastebin
+as indicated above, or you can't give up the convenience offered by JavaScript,
+such as the eyecandies and the syntax highlighting, or because you just have too much
+computational power to waste (Hey you are blessed!)... Please beware that
 our old Pastebin is still running on https://pastebin.aosc.io . A link is also offered
-at the bottom of each paste on the new Pastebin, to allow users to view them on the old
-Pastebin.
+at the bottom of each paste on the new Pastebin, allowing you to view them on the old
+Pastebin with JavaScript highlighting and more.
 
-Hey I've Got a Question!
+Hey, I've Got a Question!
 ----------
 
-If you have any further questions or feature requests, please contact the owner _S. aureus_
+If you have any further questions or feature requests, please [contact us](https://github.com/AOSC-Dev/aosc-portal-kiss.github.io/issues)!
 
 Enjoy Pasting the AOSC way!
 

--- a/content/news/posts/2020-08-06-a-facelift-for-aosc-pastebin.md
+++ b/content/news/posts/2020-08-06-a-facelift-for-aosc-pastebin.md
@@ -12,12 +12,12 @@ The new pastebin is a proxy to our old pastebin service, with a completely redes
 UI that more closely resembles our main website, and uses no JavaScript in
 order to improve compatibility, accessibility, and speed.
 
-The new pastebin is now online, accessible at https://paste.aosc.io .
+Our new pastebin is now online, accessible at https://paste.aosc.io .
 
-Any Compatibility Issues?
+Any Compatibility Issue?
 -------------------------
 Currently most basic functions are fully supported by the new
-Pastebin website. This includes basic pasting, setting title, deactivating, and setting
+pastebin website. This includes basic pasting, setting title, deactivating, and setting
 expiration time.
 
 However, a few non-essential functions are left off. This includes:
@@ -30,14 +30,14 @@ Future updates regarding which functions are getting implemented or left off wou
 How About Our Old Pastebin? 
 ---------------------------
 
-For those of you who still miss the good'ol Pastebin (which is now serving as the backend of our
-new Pastebin), either because you need a function that is not offered in the new Pastebin
+For those of you who still miss the good'ol pastebin (which is now serving as the backend of our
+new pastebin), either because you need a function that is not offered in the new pastebin
 as indicated above, or you can't give up the convenience offered by JavaScript,
 such as the eyecandies and the syntax highlighting, or because you just have too much
 computational power to waste (Hey you are blessed!)... Please beware that
-our old Pastebin is still running on https://pastebin.aosc.io . A link is also offered
-at the bottom of each paste on the new Pastebin, allowing you to view them on the old
-Pastebin with JavaScript highlighting and more.
+our old pastebin is still running on https://pastebin.aosc.io . A link is also offered
+at the bottom of each paste on the new pastebin, allowing you to view them on the old
+pastebin with JavaScript highlighting and more.
 
 Hey, I've Got a Question!
 ----------

--- a/data/navigation.en.yml
+++ b/data/navigation.en.yml
@@ -26,4 +26,4 @@
   url: /mail
 
 - title: Pastebin
-  url: https://pastebin.aosc.io/
+  url: https://paste.aosc.io/

--- a/data/navigation.lzh.yml
+++ b/data/navigation.lzh.yml
@@ -26,4 +26,4 @@
   url: /lzh/mail
 
 - title: 共用剪貼簿
-  url: https://pastebin.aosc.io/
+  url: https://pasten.aosc.io/

--- a/data/navigation.lzh.yml
+++ b/data/navigation.lzh.yml
@@ -26,4 +26,4 @@
   url: /lzh/mail
 
 - title: 共用剪貼簿
-  url: https://pasten.aosc.io/
+  url: https://paste.aosc.io/

--- a/data/navigation.zh-cn.yml
+++ b/data/navigation.zh-cn.yml
@@ -26,4 +26,4 @@
   url: /zh-cn/mail
 
 - title: 公共剪贴板
-  url: https://pastebin.aosc.io/
+  url: https://paste.aosc.io/

--- a/data/navigation.zh-tw.yml
+++ b/data/navigation.zh-tw.yml
@@ -26,4 +26,4 @@
   url: /zh-tw/mail
 
 - title: 共用剪貼簿
-  url: https://pastebin.aosc.io/
+  url: https://paste.aosc.io/


### PR DESCRIPTION
This uses an UI that more closely resembles that of the main site.

Without the use of JS also improves the usability on AOSC/Retro and other browsers.