### PR TITLE
azure-pipelines.yml: update Hugo

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -1,5 +1,5 @@
 #!/bin/bash -e
-HUGO_VERSION='0.68.3'
+HUGO_VERSION='0.88.1'
 
 echo 'Downloading Hugo...'
 wget -q "https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_Linux-64bit.deb"


### PR DESCRIPTION
~~Starting from fd3a7dc923d0d7e198dcff6f4cfbceafba6b8a25, Azure Pipelines fails to build the site, updating Hugo might help.~~

It's optional to update Hugo now, build fixed in #39.