### PR TITLE
baseof.html: fix typo to test old version of Hugo

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -134,8 +134,7 @@
             <br>
             <br>
             {{- else -}}
-            <span>{{ T "copyright" (dict "copyrightYear" $copyrightYear) }} &nbsp; | &nbsp; <a href="/lingua">{{ T
-                    "sitelang" }}</a></span>
+            <span>{{ T "copyright" (dict "copyrightYear" $copyrightYear) }} &nbsp; | &nbsp; <a href="/lingua">{{ T "sitelang" }}</a></span>
             {{- end -}}
         </div>
         <!-- !footer -->


### PR DESCRIPTION
Fix typo introduced in fd3a7dc923d0d7e198dcff6f4cfbceafba6b8a25.