### PR TITLE
Use an en dash for English copyright notice

### DIFF
--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -8,7 +8,7 @@ other = "Back"
 other = "Screenshots"
 
 [copyright]
-other = "Copyleft 2011 — {{ $.copyrightYear }}, Members of the Community"
+other = "Copyleft 2011–{{ $.copyrightYear }}, Members of the Community"
 
 [news]
 other = "News"


### PR DESCRIPTION
Year ranges for English should probably be using an [en dash](https://en.wikipedia.org/wiki/Dash#Ranges_of_values). Leaving the two Chinese files alone because em dashes ("一字线") are fine for them.